### PR TITLE
Type simplifications

### DIFF
--- a/Lurk/AST.lean
+++ b/Lurk/AST.lean
@@ -1,11 +1,5 @@
 namespace Lurk
 
-/-- Numerical values in Lurk (may be valued in a finite field) -/
-inductive Num
-  | raw    : Int → Num
-  | cyclic : Int → Nat → Num
-  deriving Repr
-
 /-- Unary operations on Lurk expressions -/
 inductive UnaryOp | car | cdr | atom | emit
 deriving Repr, BEq
@@ -19,7 +13,7 @@ inductive Literal
   -- `t` `nil`
   | t | nil
   -- Numerical values
-  | num     : Num → Literal
+  | num     : Int → Literal
   -- Strings
   | str     : String → Literal
   -- Characters

--- a/Lurk/Printer.lean
+++ b/Lurk/Printer.lean
@@ -2,10 +2,6 @@ import Lurk.AST
 
 namespace Lurk
 
-instance : ToString Num where toString
-  | .raw i      => toString i
-  | .cyclic i _ => toString i -- is this right? do we ignore the modulus?
-
 instance : ToString UnaryOp where toString
   | .car  => "car"
   | .cdr  => "cdr"
@@ -45,11 +41,11 @@ partial def Expr.print : Expr → String
     let formalsText := " ".intercalate (formals.map toString)
     s!"(lambda ({formalsText}) {print body})"
   | .letE bindings body => 
-    let bindingsTextList := bindings.map fun (name, expr) => s!"({name} {print expr})"
+    let bindingsTextList := bindings.map fun (name, expr) => s!"({name} {expr.print})"
     let bindingsText := " ".intercalate bindingsTextList
     s!"(let ({bindingsText}) {print body})"
   | .letRecE bindings body => 
-    let bindingsTextList := bindings.map fun (name, expr) => s!"({name} {print expr})"
+    let bindingsTextList := bindings.map fun (name, expr) => s!"({name} {expr.print})"
     let bindingsText := " ".intercalate bindingsTextList
     s!"(let ({bindingsText}) {print body})"
   | .app fn args => 


### PR DESCRIPTION
* Change `Num` to an inductive with dedicated constructors
* Drop `Name` and use `String` directly
* Change everything else accordingly